### PR TITLE
Added pathFromSVGString and pathFromDAttribute factory methods

### DIFF
--- a/PocketSVG.h
+++ b/PocketSVG.h
@@ -69,6 +69,24 @@
  */
 + (CGPathRef)pathFromSVGFileAtURL:(NSURL *)svgFileURL;
 
+/*!
+ *  Returns a CGPathRef corresponding to the path represented by a string with SVG formatted contents.
+ *
+ *  @param svgString The string containing the SVG formatted path.
+ *
+ *  @return A CGPathRef object for the SVG in the string, or nil if no path is found or the string could not be parsed.
+ */
++ (CGPathRef)pathFromSVGString:(NSString *)svgString;
+
+/*!
+ *  Returns a CGPathRef corresponding to the path represented by a string with the contents of the d attribute of a path node in an SVG file.
+ *
+ *  @param dAttribute The string containing the d attribute with the path.
+ *
+ *  @return A CGPathRef object for the path in the string, or nil if no path is found or the string could not be parsed.
+ */
++ (CGPathRef)pathFromDAttribute:(NSString *)dAttribute;
+
 
 /*!
  *  Returns a PocketSVG object initialized with nameOfSVG

--- a/PocketSVG.m
+++ b/PocketSVG.m
@@ -113,7 +113,18 @@ unichar const invalidCommand		= '*';
 + (CGPathRef)pathFromSVGFileAtURL:(NSURL *)svgFileURL
 {
     NSString *svgString = [[self class] svgStringAtURL:svgFileURL];
-    PocketSVG *pocketSVG = [[PocketSVG alloc] initFromSVGPathNodeDAttr:[self dStringFromRawSVGString:svgString]];
+    return [[self class] pathFromSVGString:svgString];
+}
+
++ (CGPathRef)pathFromSVGString:(NSString *)svgString
+{
+    NSString *dAttribute = [self dStringFromRawSVGString:svgString];
+    return [self pathFromDAttribute:dAttribute];
+}
+
++ (CGPathRef)pathFromDAttribute:(NSString *)dAttribute
+{
+    PocketSVG *pocketSVG = [[PocketSVG alloc] initFromSVGPathNodeDAttr:dAttribute];
 #if TARGET_OS_IPHONE
     return pocketSVG.bezier.CGPath;
 #else


### PR DESCRIPTION
These are useful for those who have complex SVG-files or embedded SVG that they want to parse themselves and leave just the path conversion to PocketSVG. (In my case I'm parsing KanjiVG).

Considering how small a change this was the need for this must have been completely nonexistent or I have failed to see some design decision that this was undesirable?
