### PR TITLE
V2 last fixes

### DIFF
--- a/Demos/Demo-iOS/Demo-iOS.xcodeproj/project.pbxproj
+++ b/Demos/Demo-iOS/Demo-iOS.xcodeproj/project.pbxproj
@@ -110,11 +110,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = PocketSVG;
 				TargetAttributes = {
 					B09D90951D6C5E2E00360396 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -189,8 +190,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -235,8 +238,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -255,6 +260,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -268,6 +274,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "PocketSVG.Demo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -279,6 +286,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "PocketSVG.Demo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Demos/Demo-iOS/Demo-iOS/AppDelegate.swift
+++ b/Demos/Demo-iOS/Demo-iOS/AppDelegate.swift
@@ -13,9 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
-        window = UIWindow(frame: UIScreen.mainScreen().bounds)
+        window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
 

--- a/Demos/Demo-iOS/Demo-iOS/ViewController.swift
+++ b/Demos/Demo-iOS/Demo-iOS/ViewController.swift
@@ -15,25 +15,26 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .whiteColor()
+        view.backgroundColor = .white
 
-        let url = NSBundle.mainBundle().URLForResource("tiger", withExtension: "svg")!
+        let url = Bundle.main.url(forResource: "tiger", withExtension: "svg")!
 
-        let svgImageView = SVGImageView(contentsOfURL: url)
+        //initialise a view that parses and renders an SVG file in the bundle:
+        let svgImageView = SVGImageView.init(contentsOf: url)
 
 
         //scale the resulting image to fit the frame of the view, but
         //maintain its aspect ratio:
-        svgImageView.contentMode = .ScaleAspectFit
+        svgImageView.contentMode = .scaleAspectFit
 
 
         //layout the view:
         svgImageView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(svgImageView)
 
-        svgImageView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
-        svgImageView.leftAnchor.constraintEqualToAnchor(view.leftAnchor).active = true
-        svgImageView.rightAnchor.constraintEqualToAnchor(view.rightAnchor).active = true
-
+        svgImageView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        svgImageView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+        svgImageView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        
     }
 }

--- a/Demos/Demo-macOS/Demo-macOS.xcodeproj/project.pbxproj
+++ b/Demos/Demo-macOS/Demo-macOS.xcodeproj/project.pbxproj
@@ -110,11 +110,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = PocketSVG;
 				TargetAttributes = {
 					B0EEE2251D6CA72100BCAF68 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -189,8 +190,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -234,8 +237,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -254,6 +259,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -266,6 +272,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "PocketSVG.Demo-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -278,6 +285,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "PocketSVG.Demo-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Demos/Demo-macOS/Demo-macOS/AppDelegate.swift
+++ b/Demos/Demo-macOS/Demo-macOS/AppDelegate.swift
@@ -13,11 +13,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 
 
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 

--- a/Demos/Demo-macOS/Demo-macOS/ViewController.swift
+++ b/Demos/Demo-macOS/Demo-macOS/ViewController.swift
@@ -17,19 +17,19 @@ class ViewController: NSViewController {
 
         view.wantsLayer = true
 
-        let url = NSBundle.mainBundle().URLForResource("iceland", withExtension: "svg")!
+        let url = Bundle.main.url(forResource: "iceland", withExtension: "svg")!
 
         //initialise a view that parses and renders an SVG file in the bundle:
-        let svgImageView = SVGImageView(contentsOfURL: url)
+        let svgImageView = SVGImageView.init(contentsOf: url)
 
 
         //layout the view:
         svgImageView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(svgImageView)
 
-        svgImageView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
-        svgImageView.leftAnchor.constraintEqualToAnchor(view.leftAnchor).active = true
-        svgImageView.rightAnchor.constraintEqualToAnchor(view.rightAnchor).active = true
-        svgImageView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor).active = true
+        svgImageView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        svgImageView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+        svgImageView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        svgImageView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
     }
 }

--- a/PocketSVG.podspec
+++ b/PocketSVG.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name         = "PocketSVG"
   s.version      = "2.0"
-  s.summary      = "An Objective-C class that converts Scalable Vector Graphics into Core Graphics elements."
-  s.homepage     = "https://github.com/arielelkin/PocketSVG"
+  s.summary      = "Easily convert your SVG files into CGPaths, CAShapeLayers, and UIBezierPaths"
+  s.homepage     = "https://github.com/pocketsvg/PocketSVG"
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.license = {
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     :file => 'LICENSE'
   }
 
-  s.authors      = { "Ponderwell, Fjölnir Ásgeirsson, Ariel Elkin, and Contributors" => "https://github.com/arielelkin/PocketSVG" }
+  s.authors      = { "Ponderwell, Fjölnir Ásgeirsson, Ariel Elkin, and Contributors" => "https://github.com/pocketsvg/PocketSVG" }
   s.source       = { :git => "https://github.com/arielelkin/PocketSVG.git", :tag => s.version }
   s.requires_arc = true
   s.frameworks  = 'QuartzCore'

--- a/PocketSVG.xcodeproj/project.pbxproj
+++ b/PocketSVG.xcodeproj/project.pbxproj
@@ -184,9 +184,11 @@
 				TargetAttributes = {
 					C79800BA1A21CB5300380860 = {
 						CreatedOnToolsVersion = 6.1;
+						LastSwiftMigration = 0800;
 					};
 					C79800F41A21CDFD00380860 = {
 						CreatedOnToolsVersion = 6.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -365,6 +367,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pocketsvg.pocketsvg;
 				PRODUCT_NAME = PocketSVG;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -385,6 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pocketsvg.pocketsvg;
 				PRODUCT_NAME = PocketSVG;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -409,6 +413,7 @@
 				PRODUCT_NAME = PocketSVG;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -430,6 +435,7 @@
 				PRODUCT_NAME = PocketSVG;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/arielelkin/PocketSVG.svg?branch=master)](https://travis-ci.org/arielelkin/PocketSVG)
 
-A simple toolkit for displaying and manipulating SVGs on iOS and macOS.
+A simple toolkit for displaying and manipulating SVGs on iOS and macOS. 
 
 Convert your SVGs into 
 
@@ -13,13 +13,14 @@ Convert your SVGs into
 * `UIBezierPath`
 * `NSBezierPath`
 
+Thoroughly documented. 
+
 ## Features
 
 * Turn your SVG into an UIView/NSView 
 * Turn your SVG into a CALayer
 * Display all kinds of SVGs shapes and paths.
 * Fully working iOS and macOS demos.
-* Thoroughly documented. 
 * Straightforward API for typical SVG rendering (`SVGLayer` and `SVGImageView`) 
 * Supports more fine-grained SVG manipulation (`SVGBezierPath` and `SVGEngine`)
 

--- a/SVGBezierPath.h
+++ b/SVGBezierPath.h
@@ -9,20 +9,49 @@
 #import "SVGPortability.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// A NSBezierPath or UIBezierPath subclass that represents an SVG path
+/// and its SVG attributes
 @interface SVGBezierPath : PSVGBezierPath
+
+
+/*!
+ *  @discussion A set of paths and their attributes.
+ *
+ */
 @property(nonatomic, readonly) NSDictionary<NSString*, id> *svgAttributes;
+
+
+/*!
+ *  @discussion The string representation of an SVG.
+ *
+ */
 @property(nonatomic, readonly) NSString *SVGRepresentation;
+
+
+
+/*!
+ *  Returns an array of SVGBezierPaths given an SVG's URL.
+ *
+ *  @param aURL The URL from which to load an SVG.
+ *
+ */
++ (NSArray<SVGBezierPath*> *)pathsFromSVGAtURL:(NSURL *)aURL;
+
+
+/*!
+ *  Returns an array of paths given the XML string of an SVG.
+ *
+ */
++ (NSArray *)pathsFromSVGString:(NSString *)svgString;
+
+
 #if !TARGET_OS_IPHONE
 @property(nonatomic, readonly) CGPathRef CGPath;
 #endif
 
-+ (void)resetCache;
 
-+ (NSArray<SVGBezierPath*> *)pathsFromSVGNamed:(NSString *)aName;
-+ (NSArray<SVGBezierPath*> *)pathsFromSVGNamed:(NSString *)aName inBundle:(NSBundle *)bundle;
-+ (NSArray<SVGBezierPath*> *)pathsFromContentsOfSVGFile:(NSString *)aPath;
-+ (NSArray<SVGBezierPath*> *)pathsFromSVGAtURL:(NSURL *)aURL;
-+ (NSArray *)pathsFromSVGString:(NSString *)svgString;
++ (void)resetCache;
 
 
 #if !TARGET_OS_IPHONE

--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -39,39 +39,14 @@
     [self._svg_pathCache removeAllObjects];
 }
 
-+ (NSArray *)pathsFromSVGNamed:(NSString * const)aName
-{
-    return [self pathsFromSVGNamed:aName inBundle:[NSBundle mainBundle]];
-}
-+ (NSArray<SVGBezierPath*> *)pathsFromSVGNamed:(NSString * const)aName inBundle:(NSBundle * const)aBundle
-{
-    NSArray<SVGBezierPath*> *paths = [self._svg_pathCache objectForKey:aName];
-    if (!paths) {
-        NSString *path = [aBundle pathForResource:aName ofType:@"svg"];
-        paths = [self pathsFromContentsOfSVGFile:path];
-        if (paths) {
-            [self._svg_pathCache setObject:paths forKey:aName];
-        }
-    }
-    return [[NSArray alloc] initWithArray:paths copyItems:YES];
-}
-
 + (NSArray<SVGBezierPath*> *)pathsFromSVGAtURL:(NSURL *)aURL
 {
     return [self pathsFromSVGString:[NSString stringWithContentsOfURL:aURL
                                                          usedEncoding:NULL
                                                                 error:NULL]];
 }
-+ (NSArray *)pathsFromContentsOfSVGFile:(NSString * const)aPath
-{
-#ifndef NS_BLOCK_ASSERTIONS
-    BOOL isDir;
-    NSParameterAssert([[NSFileManager defaultManager] fileExistsAtPath:aPath isDirectory:&isDir] && !isDir);
-#endif
-    return [self pathsFromSVGString:[NSString stringWithContentsOfFile:aPath
-                                                          usedEncoding:NULL
-                                                                 error:nil]];
-}
+
+
 
 + (NSArray *)pathsFromSVGString:(NSString * const)svgString
 {

--- a/SVGImageView.h
+++ b/SVGImageView.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
  let svgImageView = SVGImageView(contentsOfURL: url)
  *
  */
-
 - (instancetype)initWithContentsOfURL:(NSURL *)url;
 
 

--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -150,11 +150,10 @@ CGRect _AdjustCGRectForContentsGravity(CGRect aRect, CGSize aSize, NSString *aGr
     self.svgSource = [NSString stringWithContentsOfFile:path
                                        usedEncoding:NULL
                                               error:nil];
-#if !TARGET_INTERFACE_BUILDER
-    [self _cr_setPaths:[SVGBezierPath pathsFromSVGNamed:svgName inBundle:bundle]];
-#else
-    [self _cr_setPaths:[SVGBezierPath pathsFromContentsOfSVGFile:path]];
-#endif
+
+
+    [self _cr_setPaths:[SVGBezierPath pathsFromSVGString:self.svgSource]];
+
     [self didChangeValueForKey:@"svgSource"];
 
 #ifdef DEBUG


### PR DESCRIPTION
* upgrades to Xcode 8
* updates demos for Swift 3
* add documentation for `SVGBezierPath.h`
* SVGBezierPaths loads only from URLs or XML strings (to be consistent with the API)

@fjolnir could you please help me clarify the following from SVGBezierPath?
* `resetCache`
* the `CGPath` property: which CGPath is it returning? 
* does `pathsFromSVGString` return an array of SVGBezierPaths?