### PR TITLE
Fixed path bounds calculation for SVGs if line width is scaled and > 1

### DIFF
--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -195,7 +195,14 @@ CGRect _AdjustCGRectForContentsGravity(CGRect aRect, CGSize aSize, NSString *aGr
 {
     CGRect bounds = CGRectZero;
     for(SVGBezierPath *path in _untouchedPaths) {
-        bounds = CGRectUnion(bounds, path.bounds);
+        CGRect pathBounds = path.bounds;
+        CGFloat lineWidth = [path.svgAttributes[@"stroke-width"] floatValue];
+        if (_scaleLineWidth && lineWidth > 1.0) {
+            CGPathRef pathRef = CGPathCreateCopyByStrokingPath(path.CGPath, NULL, lineWidth, path.lineCapStyle, path.lineJoinStyle, path.miterLimit);
+            pathBounds = CGPathGetPathBoundingBox(pathRef);
+            CGPathRelease(pathRef);
+        }
+        bounds = CGRectUnion(bounds, pathBounds);
     }
     return bounds.size;
 }


### PR DESCRIPTION
Hi,
we had some problems with rendered SVGs getting cropped when using `scaleLineWidth` if line width is > 1.0. First tried to solve it by expanding layer bounds by `path.lineWidth * scale` on the edges, but of course that only worked for for example squares and circles, but not for a bezier curve or something like [this](https://github.com/raumfeld/RFSVG/blob/line-width-fix/Example/unicorn-stroked.svg). It's a but grotesque, but should illustrate the point:

Rendered in web view:
<img width="100" alt="reference_testcomparewithwebview_unicorn-stroked svg 2x" src="https://cloud.githubusercontent.com/assets/1700318/22889484/9d31ccc6-f209-11e6-83b7-f292d28027ef.png">
Rendered by PocketSVG:
<img width="100" alt="failed_testcomparewithwebview_unicorn-stroked svg 2x" src="https://cloud.githubusercontent.com/assets/1700318/22889487/a0abb786-f209-11e6-95b7-52ddad19b486.png">

After some digging and writing snapshot tests by comparing SVGs rendered by `UIWebView` vs ones rendered by PocketSVG, I've found that Core Graphics has an "out of the box solution" and `CGPathGetPathBoundingBox` correctly calculates the bounds for that case.

Caveat is I'm still scratching my head why `CGPathGetPathBoundingBox` works, but `CGPathGetBoundingBox` not. Per documentation:

`CGPathGetBoundingBox`:
> The path bounding box is the smallest rectangle completely enclosing all points in the path but **not including control points** for Bézier and quadratic curves.

`CGPathGetPathBoundingBox`:
> The bounding box is the smallest rectangle completely enclosing all points in the path, **including control points** for Bézier and quadratic curves.

Note: emphasis in quotes mine, control points being illustrated [here](https://developer.apple.com/library/content/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/Art/curve_segments_2x.png).

Let me know if you have feedback on this or know of a better way how to deal with this.

On a separate note, I'd like to contribute by writing unit tests that do a snapshot comparison of SVGs rendered by `UIWebView` vs ones rendered by PocketSVG as mentioned above, but would need help with finding enough "free to use" SVGs. Point being, for these kind of tests more is better, unless you think a few select ones are sufficient to cover most cases.