### PR TITLE
Fixed incorrect transform

### DIFF
--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -206,7 +206,6 @@ extern "C" void SVGDrawPaths(NSArray<SVGBezierPath*> * const paths,
                                                                rect.size.height / bounds.size.height);
 
     CGContextSaveGState(ctx);
-    CGContextConcatCTM(ctx, scale);
     CGContextTranslateCTM(ctx, rect.origin.x, rect.origin.y);
     for (SVGBezierPath *path in paths) {
         CGContextSaveGState(ctx);


### PR DESCRIPTION
Scaling was applied first, then re-applied as concatenation of each path's transform, resulting in incorrect size / position