### PR TITLE
Use CGPathAddRoundedRect to generate Rect.

### DIFF
--- a/Demos/Demo-iOS/Demo-iOS.xcodeproj/project.pbxproj
+++ b/Demos/Demo-iOS/Demo-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07AA8AA01F0476B800DDA64A /* Rectangle.svg in Resources */ = {isa = PBXBuildFile; fileRef = 07AA8A9F1F0476B800DDA64A /* Rectangle.svg */; };
 		1DC60E3D1E2B91D30044BFD3 /* Circle.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1DC60E3C1E2B91D30044BFD3 /* Circle.svg */; };
 		1DC60E481E2BA1170044BFD3 /* PocketSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DC60E471E2BA1170044BFD3 /* PocketSVG.framework */; };
 		1DC60E4B1E2BA48F0044BFD3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1DC60E491E2BA48F0044BFD3 /* Main.storyboard */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		07AA8A9F1F0476B800DDA64A /* Rectangle.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = Rectangle.svg; sourceTree = "<group>"; };
 		1DC60E3C1E2B91D30044BFD3 /* Circle.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = Circle.svg; sourceTree = "<group>"; };
 		1DC60E471E2BA1170044BFD3 /* PocketSVG.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PocketSVG.framework; path = "../../build/Debug-iphoneos/PocketSVG.framework"; sourceTree = "<group>"; };
 		1DC60E4A1E2BA48F0044BFD3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -58,6 +60,7 @@
 				B03797391D6CAECB00E9FF84 /* BezierCurve.svg */,
 				B037973A1D6CAECB00E9FF84 /* iceland.svg */,
 				B037973B1D6CAECB00E9FF84 /* tiger.svg */,
+				07AA8A9F1F0476B800DDA64A /* Rectangle.svg */,
 				1DC60E3C1E2B91D30044BFD3 /* Circle.svg */,
 			);
 			name = "Sample SVG Files";
@@ -153,6 +156,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07AA8AA01F0476B800DDA64A /* Rectangle.svg in Resources */,
 				1DC60E3D1E2B91D30044BFD3 /* Circle.svg in Resources */,
 				B037973C1D6CAECB00E9FF84 /* BezierCurve.svg in Resources */,
 				B037973D1D6CAECB00E9FF84 /* iceland.svg in Resources */,

--- a/Demos/Sample SVG Files/Rectangle.svg
+++ b/Demos/Sample SVG Files/Rectangle.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="500px" height="500px" viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <g id="Page-1" stroke="#fff000" stroke-width="2px" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+    <rect x="10" y="10" width="100px" height="100px" rx="10px" ry="10px"></rect>
+    </g>
+</svg>

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -169,29 +169,18 @@ CF_RETURNS_RETAINED CGPathRef svgParser::readPathTag()
 CF_RETURNS_RETAINED CGPathRef svgParser::readRectTag()
 {
     NSCAssert(strcasecmp((char*)xmlTextReaderConstName(_xmlReader), "rect") == 0,
-              @"Not on a <polygon>");
+              @"Not on a <rect>");
 
     CGRect const rect = {
         readFloatAttribute(@"x"),     readFloatAttribute(@"y"),
         readFloatAttribute(@"width"), readFloatAttribute(@"height")
     };
-    NSString * const pathDefinition = [NSString stringWithFormat:
-                                       @"M%@,%@"
-                                       @"H%@V%@"
-                                       @"H%@V%@Z",
-                                       _SVGFormatNumber(@(CGRectGetMinX(rect))),
-                                       _SVGFormatNumber(@(CGRectGetMinY(rect))),
-                                       _SVGFormatNumber(@(CGRectGetMaxX(rect))),
-                                       _SVGFormatNumber(@(CGRectGetMaxY(rect))),
-                                       _SVGFormatNumber(@(CGRectGetMinX(rect))),
-                                       _SVGFormatNumber(@(CGRectGetMinY(rect)))];
+    float rx = readFloatAttribute(@"rx");
+    float ry = readFloatAttribute(@"ry");
 
-    CGPathRef const path = pathDefinitionParser(pathDefinition).parse();
-    if(!path) {
-        NSLog(@"*** Error: Invalid path attribute");
-        return NULL;
-    } else
-        return path;
+    CGMutablePathRef rectPath = CGPathCreateMutable();
+    CGPathAddRoundedRect(rectPath, NULL, rect, rx, ry);
+    return rectPath;
 }
 
 CF_RETURNS_RETAINED CGPathRef svgParser::readPolygonTag()


### PR DESCRIPTION
That's a proposal PR, apparently, it should start using  [rx](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx) and [ry](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry)  arguments of [\<rect\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect).
Also, there's already a  [CGPathAddRoundedRect](https://developer.apple.com/documentation/coregraphics/1411124-cgpathaddroundedrect) to generate rect instead of creating a path tag. 

Thanks for your comments in advance! 

Supposedly, it will fix https://github.com/pocketsvg/PocketSVG/issues/85

Cheers 🍻 