### PR TITLE
Use svgAttributes when generating SVGRepresentation for SVGBezierPath

### DIFF
--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -74,7 +74,7 @@
 {
     SVGMutableAttributeSet *attributes = [SVGMutableAttributeSet new];
     [attributes setAttributes:self.svgAttributes forPath:self.CGPath];
-    return SVGStringFromCGPaths(@[(__bridge id)self.CGPath], [attributes copy]);
+    return SVGStringFromCGPaths(@[(__bridge id)self.CGPath], attributes);
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone

--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -72,8 +72,11 @@
 
 - (NSString *)SVGRepresentation
 {
-    return SVGStringFromCGPaths(@[(__bridge id)self.CGPath], nil);
+    SVGMutableAttributeSet *attributes = [SVGMutableAttributeSet new];
+    [attributes setAttributes:self.svgAttributes forPath:self.CGPath];
+    return SVGStringFromCGPaths(@[(__bridge id)self.CGPath], [attributes copy]);
 }
+
 - (instancetype)copyWithZone:(NSZone *)zone
 {
     SVGBezierPath * const copy = [super copyWithZone:zone];


### PR DESCRIPTION
Fixes #112 