### PR TITLE
Retain CGColorRefs

### DIFF
--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -50,6 +50,12 @@
     return self;
 }
 
+- (void)dealloc
+{
+    CGColorRelease(_fillColor);
+    CGColorRelease(_strokeColor);
+}
+
 - (void)setPaths:(NSArray<SVGBezierPath*> *)paths
 {
     [self willChangeValueForKey:@"paths"];
@@ -86,13 +92,19 @@
 
 - (void)setFillColor:(CGColorRef)aColor
 {
+    CGColorRetain(aColor);
+    CGColorRelease(_fillColor);
     _fillColor = aColor;
+
     [_shapeLayers setValue:(__bridge id)_fillColor forKey:@"fillColor"];
 }
 
 - (void)setStrokeColor:(CGColorRef)aColor
 {
+    CGColorRetain(aColor);
+    CGColorRelease(_strokeColor);
     _strokeColor = aColor;
+
     [_shapeLayers setValue:(__bridge id)_strokeColor forKey:@"strokeColor"];
 }
 


### PR DESCRIPTION
I was seeing some strange behaviour where setting the colours _prior_ to loading an SVG seemed to just ignore any colours that I had set, but only for non-default colours (i.e. colours created from their rgb component values, not `UIColor.redColor`).
I tracked this down to the `CGColorRef` objects not being retained by these property setters.
TBH I"m surprised that the result was just "not using the colour" rather than a crash of some description, but ¯\\_(ツ)_/¯