### PR TITLE
Prevent reading off the end of the buffer if transformation arguments are (validly) omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. Items under
 ### Fixes
 ### Internal Changes
 - Add unit tests. Ariel Elkin.
+- Deal with optional transformation arguments. Scott Talbot [#122](https://github.com/pocketsvg/PocketSVG/pull/122)
 
 ## [2.4.0]
 ### New Features

--- a/PocketSVG.xcodeproj/project.pbxproj
+++ b/PocketSVG.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 /* Begin PBXFileReference section */
 		1DC5ADD11CC9B17A008FDA98 /* SVGBezierPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGBezierPath.h; sourceTree = "<group>"; };
 		1DC5ADD21CC9B17A008FDA98 /* SVGBezierPath.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SVGBezierPath.mm; sourceTree = "<group>"; };
+		3D222DA420760F6700A6671B /* PocketSVGTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PocketSVGTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B07359AE20755E0900D88B19 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		B0B5921B207510AC0009ECA2 /* SVGColors.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SVGColors.plist; sourceTree = SOURCE_ROOT; };
 		B0B5922B20752E980009ECA2 /* PocketSVGTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PocketSVGTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -102,6 +103,7 @@
 		B0B5922C20752E980009ECA2 /* PocketSVGTests */ = {
 			isa = PBXGroup;
 			children = (
+				3D222DA420760F6700A6671B /* PocketSVGTests-Bridging-Header.h */,
 				B0B5922D20752E980009ECA2 /* PocketSVGTests.swift */,
 				B0B5922F20752E980009ECA2 /* Info.plist */,
 				B0B59246207532D40009ECA2 /* test_rectangle.svg */,
@@ -375,6 +377,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = pocketSVG.PocketSVGTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "PocketSVGTests/PocketSVGTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -405,6 +408,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = pocketSVG.PocketSVGTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "PocketSVGTests/PocketSVGTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/PocketSVGTests/PocketSVGTests-Bridging-Header.h
+++ b/PocketSVGTests/PocketSVGTests-Bridging-Header.h
@@ -1,0 +1,14 @@
+/*
+ * This file is part of the PocketSVG package.
+ * Copyright (c) Ponderwell, Ariel Elkin, Fjölnir Ásgeirsson, and Contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#ifndef PocketSVGTests_Bridging_Header_h
+#define PocketSVGTests_Bridging_Header_h
+
+#import "SVGEngine.h"
+
+#endif /* PocketSVGTests_Bridging_Header_h */

--- a/PocketSVGTests/PocketSVGTests.swift
+++ b/PocketSVGTests/PocketSVGTests.swift
@@ -82,5 +82,81 @@ class PocketSVGTests: XCTestCase {
 
         XCTAssertEqual(rectanglePath.svgRepresentation, representation)
     }
-    
+
+    func testTransformTranslate() {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <g transform="translate(10 5)">
+                    <rect x="20" y="20" width="60" height="60"/>
+                </g>
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        XCTAssertEqual(paths.count, 1)
+
+        guard let path = paths.first else {
+            return
+        }
+
+        let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
+        XCTAssertEqual(pathTransform, CGAffineTransform(translationX: 10, y: 5))
+    }
+
+    func testTransformTranslateOptionalParameters() {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <g transform="translate(10)">
+                    <rect x="20" y="20" width="60" height="60"/>
+                </g>
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        XCTAssertEqual(paths.count, 1)
+
+        guard let path = paths.first else {
+            return
+        }
+
+        let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
+        XCTAssertEqual(pathTransform, CGAffineTransform(translationX: 10, y: 0))
+    }
+
+    func testTransformScale() {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <g transform="scale(2 2)">
+                    <rect x="20" y="20" width="30" height="30"/>
+                </g>
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        XCTAssertEqual(paths.count, 1)
+
+        guard let path = paths.first else {
+            return
+        }
+
+        let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
+        XCTAssertEqual(pathTransform, CGAffineTransform(scaleX: 2, y: 2))
+    }
+
+    func testTransformScaleOptionalParameters() {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <g transform="scale(2)">
+                    <rect x="20" y="20" width="60" height="60"/>
+                </g>
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        XCTAssertEqual(paths.count, 1)
+
+        guard let path = paths.first else {
+            return
+        }
+
+        let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
+        XCTAssertEqual(pathTransform, CGAffineTransform(scaleX: 2, y: 2))
+    }
+
 }

--- a/SVGBezierPath.h
+++ b/SVGBezierPath.h
@@ -55,7 +55,7 @@ FOUNDATION_EXTERN void SVGDrawPathsWithBlock(NSArray<SVGBezierPath*> * const pat
  * @brief Returns an array of paths given the XML string of an SVG.
  *
  */
-+ (NSArray *)pathsFromSVGString:(NSString *)svgString;
++ (NSArray<SVGBezierPath*> *)pathsFromSVGString:(NSString *)svgString;
 
 /*!
  * @brief Returns a new path with the values of `attributes` added to `svgAttributes`

--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -54,11 +54,11 @@
     return [[NSArray alloc] initWithArray:paths copyItems:YES];
 }
 
-+ (NSArray *)pathsFromSVGString:(NSString * const)svgString
++ (NSArray<SVGBezierPath*> *)pathsFromSVGString:(NSString * const)svgString
 {
     SVGAttributeSet *cgAttrs;
-    NSArray        * const pathRefs = CGPathsFromSVGString(svgString, &cgAttrs);
-    NSMutableArray * const paths    = [NSMutableArray arrayWithCapacity:pathRefs.count];
+    NSArray * const pathRefs = CGPathsFromSVGString(svgString, &cgAttrs);
+    NSMutableArray<SVGBezierPath*> * const paths = [NSMutableArray arrayWithCapacity:pathRefs.count];
     for(id pathRef in pathRefs) {
         SVGBezierPath * const uiPath = [self bezierPathWithCGPath:(__bridge CGPathRef)pathRef];
         uiPath->_svgAttributes = [cgAttrs attributesForPath:(__bridge CGPathRef)pathRef] ?: @{};

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -331,11 +331,19 @@ NSDictionary *svgParser::readAttributes()
                                                                     -sinf(radians), cosf(radians),
                                                                     0, 0);
                     }
-                } else if([transformCmd isEqualToString:@"translate"])
-                    additionalTransform = CGAffineTransformMakeTranslation(transformOperands[0], transformOperands[1]);
-                else if([transformCmd isEqualToString:@"scale"])
-                    additionalTransform = CGAffineTransformMakeScale(transformOperands[0], transformOperands[1]);
-                else if([transformCmd isEqualToString:@"skewX"])
+                } else if([transformCmd isEqualToString:@"translate"]) {
+                    float tx = transformOperands[0];
+                    float ty = 0;
+                    if (transformOperands.size() > 1)
+                        ty = transformOperands[1];
+                    additionalTransform = CGAffineTransformMakeTranslation(tx, ty);
+                } else if([transformCmd isEqualToString:@"scale"]) {
+                    float sx = transformOperands[0];
+                    float sy = sx;
+                    if (transformOperands.size() > 1)
+                        sy = transformOperands[1];
+                    additionalTransform = CGAffineTransformMakeScale(sx, sy);
+                } else if([transformCmd isEqualToString:@"skewX"])
                     additionalTransform.c = tanf(transformOperands[0] * M_PI / 180.0);
                 else if([transformCmd isEqualToString:@"skewY"])
                     additionalTransform.b = tanf(transformOperands[0] * M_PI / 180.0);

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -313,11 +313,11 @@ NSDictionary *svgParser::readAttributes()
                     transformOperands.push_back(operand));
 
                 CGAffineTransform additionalTransform = CGAffineTransformIdentity;
-                if([transformCmd isEqualToString:@"matrix"])
+                if([transformCmd isEqualToString:@"matrix"] && transformOperands.size() >= 6) {
                     additionalTransform = CGAffineTransformMake(transformOperands[0], transformOperands[1],
                                                                 transformOperands[2], transformOperands[3],
                                                                 transformOperands[4], transformOperands[5]);
-                else if([transformCmd isEqualToString:@"rotate"]) {
+                } else if([transformCmd isEqualToString:@"rotate"] && transformOperands.size() >= 1) {
                     float const radians = transformOperands[0] * M_PI / 180.0;
                     if (transformOperands.size() == 3) {
                         float const x = transformOperands[1];
@@ -331,22 +331,23 @@ NSDictionary *svgParser::readAttributes()
                                                                     -sinf(radians), cosf(radians),
                                                                     0, 0);
                     }
-                } else if([transformCmd isEqualToString:@"translate"]) {
+                } else if([transformCmd isEqualToString:@"translate"] && transformOperands.size() >= 1) {
                     float tx = transformOperands[0];
                     float ty = 0;
-                    if (transformOperands.size() > 1)
+                    if (transformOperands.size() >= 2)
                         ty = transformOperands[1];
                     additionalTransform = CGAffineTransformMakeTranslation(tx, ty);
-                } else if([transformCmd isEqualToString:@"scale"]) {
+                } else if([transformCmd isEqualToString:@"scale"] && transformOperands.size() >= 1) {
                     float sx = transformOperands[0];
                     float sy = sx;
-                    if (transformOperands.size() > 1)
+                    if (transformOperands.size() >= 2)
                         sy = transformOperands[1];
                     additionalTransform = CGAffineTransformMakeScale(sx, sy);
-                } else if([transformCmd isEqualToString:@"skewX"])
+                } else if([transformCmd isEqualToString:@"skewX"] && transformOperands.size() >= 1) {
                     additionalTransform.c = tanf(transformOperands[0] * M_PI / 180.0);
-                else if([transformCmd isEqualToString:@"skewY"])
+                } else if([transformCmd isEqualToString:@"skewY"] && transformOperands.size() >= 1) {
                     additionalTransform.b = tanf(transformOperands[0] * M_PI / 180.0);
+                }
 
                 transform = CGAffineTransformConcat(additionalTransform, transform);
             }


### PR DESCRIPTION
The `translate` and `scale` transformations have optional arguments ([MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform)), but if they are omitted then the parser blindly reads past the end of its`transformOperands` vector.

This change actually provides default (safe) values for mandatory arguments for the `translate` and `scale` operations as well, since that's probably better than reading _something_ out of an empty vector? I haven't touched the other operations though, so they're inconsistent in that regard. Would it be better to undo the part of this change that allows for the first operands to be omitted? e.g. by applying this diff:
```diff
--- i/SVGEngine.mm
+++ w/SVGEngine.mm
@@ -332,16 +332,13 @@ @interface SVGAttributeSet () {
                                                                     0, 0);
                     }
                 } else if([transformCmd isEqualToString:@"translate"]) {
-                    float tx = 0, ty = 0;
-                    if (transformOperands.size() > 0)
-                        tx = transformOperands[0];
+                    float tx = transformOperands[0];
+                    float ty = 0;
                     if (transformOperands.size() > 1)
                         ty = transformOperands[1];
                     additionalTransform = CGAffineTransformMakeTranslation(tx, ty);
                 } else if([transformCmd isEqualToString:@"scale"]) {
-                    float sx = 1;
-                    if (transformOperands.size() > 0)
-                        sx = transformOperands[0];
+                    float sx = transformOperands[0];
                     float sy = sx;
                     if (transformOperands.size() > 1)
                         sy = transformOperands[1];
```