### PR TITLE
Path generation: don't move to 0, 0 when not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project will be documented in this file. Items under
 ### New Features
 ### Fixes
 - Add support for integer function SVG colors: rgb(int, int, int). Clément Beffa
-- Insert moveto origin commands only if necessary to fix iOS 12 path generation regression. [Noah Gilmore](https://github.com/noahsark769)  [#128](https://github.com/pocketsvg/PocketSVG/pull/128)
 ### Internal Changes
 - Add unit tests. Ariel Elkin.
 - Handle attributes on `<a>` elements and ignore unknown elements. Scott Talbot [#121](https://github.com/pocketsvg/PocketSVG/pull/121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Items under
 ### New Features
 ### Fixes
 - Add support for integer function SVG colors: rgb(int, int, int). Clément Beffa
+- Insert moveto origin commands only if necessary to fix iOS 12 path generation regression. [Noah Gilmore](https://github.com/noahsark769)  [#128](https://github.com/pocketsvg/PocketSVG/pull/128)
 ### Internal Changes
 - Add unit tests. Ariel Elkin.
 - Handle attributes on `<a>` elements and ignore unknown elements. Scott Talbot [#121](https://github.com/pocketsvg/PocketSVG/pull/121)

--- a/PocketSVGTests/PocketSVGTests.swift
+++ b/PocketSVGTests/PocketSVGTests.swift
@@ -51,7 +51,7 @@ class PocketSVGTests: XCTestCase {
         firstPath.addCurve(to: CGPoint(x: -160.83000230789185, y: 40.309001922607422), controlPoint1: CGPoint(x: -123.85000306367874, y: 86.141003662720323), controlPoint2: CGPoint(x: -140.30000352859497, y: 38.066001892089844))
         firstPath.addCurve(to: CGPoint(x: -122.30000352859497, y: 84.285003662109375), controlPoint1: CGPoint(x: -160.83000230789185, y: 40.309001922607422), controlPoint2: CGPoint(x: -143.05000162124634, y: 32.956001758575439))
         firstPath.close()
-        XCTAssertEqual(firstPath.cgPath, paths[0].cgPath)
+        XCTAssert(firstPath.cgPath == paths[0].cgPath)
 
 
         let hundredthPath = UIBezierPath()
@@ -209,22 +209,6 @@ class PocketSVGTests: XCTestCase {
 
         let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
         XCTAssertEqual(pathTransform, CGAffineTransform(scaleX: 2, y: 2))
-    }
-
-    /**
-     * Test that path bounding boxes are correct to prevent issues like
-     * https://github.com/pocketsvg/PocketSVG/issues/128
-     */
-    func testBoundingBox() {
-        let svgString = """
-            <svg xmlns="http://www.w3.org/2000/svg">
-                <path d="M21 256 l0 -235 235 0 235 0 0 235 0 235 -235 0 -235 0 0 -235z" />
-            </svg>
-            """
-        let paths = SVGBezierPath.paths(fromSVGString: svgString)
-        XCTAssertEqual(paths.count, 1)
-        let path = paths.first!
-        XCTAssertEqual(path.cgPath.boundingBox, CGRect(x: 21, y: 21, width: 470, height: 470))
     }
 
 }

--- a/PocketSVGTests/PocketSVGTests.swift
+++ b/PocketSVGTests/PocketSVGTests.swift
@@ -51,7 +51,7 @@ class PocketSVGTests: XCTestCase {
         firstPath.addCurve(to: CGPoint(x: -160.83000230789185, y: 40.309001922607422), controlPoint1: CGPoint(x: -123.85000306367874, y: 86.141003662720323), controlPoint2: CGPoint(x: -140.30000352859497, y: 38.066001892089844))
         firstPath.addCurve(to: CGPoint(x: -122.30000352859497, y: 84.285003662109375), controlPoint1: CGPoint(x: -160.83000230789185, y: 40.309001922607422), controlPoint2: CGPoint(x: -143.05000162124634, y: 32.956001758575439))
         firstPath.close()
-        XCTAssert(firstPath.cgPath == paths[0].cgPath)
+        XCTAssertEqual(firstPath.cgPath, paths[0].cgPath)
 
 
         let hundredthPath = UIBezierPath()
@@ -60,7 +60,7 @@ class PocketSVGTests: XCTestCase {
         hundredthPath.addCurve(to: CGPoint(x: 296.5, y: 162.5), controlPoint1: CGPoint(x: 230.1899995803833, y: 120.64000010490417), controlPoint2: CGPoint(x: 291.5, y: 152))
         hundredthPath.addCurve(to: CGPoint(x: 294.5, y: 153), controlPoint1: CGPoint(x: 296.5, y: 162.5), controlPoint2: CGPoint(x: 298.5, y: 160))
         hundredthPath.close()
-        XCTAssert(hundredthPath.cgPath == paths[100].cgPath)
+        XCTAssertEqual(hundredthPath.cgPath, paths[100].cgPath)
     }
 
     func testSVGRepresentationWhenUsingSettingSVGAttributes() {
@@ -209,6 +209,22 @@ class PocketSVGTests: XCTestCase {
 
         let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
         XCTAssertEqual(pathTransform, CGAffineTransform(scaleX: 2, y: 2))
+    }
+
+    /**
+     * Test that path bounding boxes are correct to prevent issues like
+     * https://github.com/pocketsvg/PocketSVG/issues/128
+     */
+    func testBoundingBox() {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 256 l0 -235 235 0 235 0 0 235 0 235 -235 0 -235 0 0 -235z" />
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        XCTAssertEqual(paths.count, 1)
+        let path = paths.first!
+        XCTAssertEqual(path.cgPath.boundingBox, CGRect(x: 21, y: 21, width: 470, height: 470))
     }
 
 }

--- a/PocketSVGTests/PocketSVGTests.swift
+++ b/PocketSVGTests/PocketSVGTests.swift
@@ -51,7 +51,7 @@ class PocketSVGTests: XCTestCase {
         firstPath.addCurve(to: CGPoint(x: -160.83000230789185, y: 40.309001922607422), controlPoint1: CGPoint(x: -123.85000306367874, y: 86.141003662720323), controlPoint2: CGPoint(x: -140.30000352859497, y: 38.066001892089844))
         firstPath.addCurve(to: CGPoint(x: -122.30000352859497, y: 84.285003662109375), controlPoint1: CGPoint(x: -160.83000230789185, y: 40.309001922607422), controlPoint2: CGPoint(x: -143.05000162124634, y: 32.956001758575439))
         firstPath.close()
-        XCTAssert(firstPath.cgPath == paths[0].cgPath)
+        XCTAssertEqual(firstPath.cgPath, paths[0].cgPath)
 
 
         let hundredthPath = UIBezierPath()
@@ -209,6 +209,22 @@ class PocketSVGTests: XCTestCase {
 
         let pathTransform = (path.svgAttributes["transform"]! as! NSValue).svg_CGAffineTransform();
         XCTAssertEqual(pathTransform, CGAffineTransform(scaleX: 2, y: 2))
+    }
+
+    /**
+     * Test that path bounding boxes are correct to prevent issues like
+     * https://github.com/pocketsvg/PocketSVG/issues/128
+     */
+    func testBoundingBox() {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 256 l0 -235 235 0 235 0 0 235 0 235 -235 0 -235 0 0 -235z" />
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        XCTAssertEqual(paths.count, 1)
+        let path = paths.first!
+        XCTAssertEqual(path.cgPath.boundingBox, CGRect(x: 21, y: 21, width: 470, height: 470))
     }
 
 }

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -493,7 +493,6 @@ CF_RETURNS_RETAINED CGMutablePathRef pathDefinitionParser::parse()
     NSLog(@"d=%@", attr);
 #endif
     _path = CGPathCreateMutable();
-    CGPathMoveToPoint(_path, NULL, 0, 0);
 
     NSScanner * const scanner = [NSScanner scannerWithString:_definition];
     static NSCharacterSet *separators, *commands;
@@ -521,6 +520,12 @@ CF_RETURNS_RETAINED CGMutablePathRef pathDefinitionParser::parse()
 #endif
         _lastCmd = _cmd;
         _cmd = [cmdBuf characterAtIndex:0];
+
+        if (![[cmdBuf substringToIndex:1].uppercaseString isEqualToString:@"M"] && CGPathIsEmpty(_path)) {
+            // Workaround for https://github.com/pocketsvg/PocketSVG/issues/128
+            CGPathMoveToPoint(_path, NULL, 0, 0);
+        }
+
         switch(_cmd) {
             case 'M': case 'm':
                 appendMoveTo();


### PR DESCRIPTION
Fixes #128 

There was an issue with iOS 12 where previously, CGPath would collapse two consecutive move statements into one. This is no longer the case on iOS 12, so paths which start with move commands to points other than the origin ended up with incorrect bounding boxes, because we started every path with a `moveto 0, 0` in order to set up paths whose first command was not a move.

After this diff, we no longer move to 0, 0 if we don't need to. Instead, when appending each command, we check if we need to append a `moveto 0, 0` first. We need to do this check in every command parsing method except `appendMoveTo`, but I figured this approach would be more robust than trying to look at the first command and see if it was a move.

I also wrote a test which exposed the iOS 12 regression.

@fjolnir feel free to review whenever :)