### PR TITLE
Added support for elliptical arc commands sequence after a single "a"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. Items under
 ## [Unreleased]
 ### New Features
 ### Fixes
-- Added support for elliptical arc commands sequence of after a single "a". Vladimir Roganov [#142](https://github.com/pocketsvg/PocketSVG/pull/142)
+- Added support for elliptical arc commands sequence of after a single "a". Vladimir Roganov [#143](https://github.com/pocketsvg/PocketSVG/pull/143)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. Items under
 ## [Unreleased]
 ### New Features
 ### Fixes
+- Added support for elliptical arc commands sequence of after a single "a". Vladimir Roganov [#142](https://github.com/pocketsvg/PocketSVG/pull/142)
+
 ### Internal Changes
 
 ## [2.4.2]

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -745,101 +745,104 @@ static CGPoint mapToEllipse(double x, double y, double rx, double ry, double cos
 
 void pathDefinitionParser::appendArc()
 {
-    if (_operands.size() != 7) {
+    if (_operands.size()%7 != 0) {
         NSLog(@"*** Error: Invalid number of parameters for A command");
         return;
     }
-    CGPoint const currentPoint = CGPathGetCurrentPoint(_path);
-
-    double const px = currentPoint.x;
-    double const py = currentPoint.y;
-    double rx = _operands[0];
-    double ry = _operands[1];
-    double const xAxisRotation = _operands[2];
-    double const largeArcFlag = _operands[3];
-    double const sweepFlag = _operands[4];
-    double const cx = _operands[5] + (_cmd == 'a' ? currentPoint.x : 0);
-    double const cy = _operands[6] + (_cmd == 'a' ? currentPoint.y : 0);
-
-    const double TAU = M_PI * 2.0;
-
-    const double sinphi = sin(xAxisRotation * TAU / 360);
-    const double cosphi = cos(xAxisRotation * TAU / 360);
-
-    const double pxp = cosphi * (px - cx) / 2 + sinphi * (py - cy) / 2;
-    const double pyp = -sinphi * (px - cx) / 2 + cosphi * (py - cy) / 2;
-
-    if (pxp == 0 && pyp == 0) {
-        return;
-    }
-
-    rx = abs(rx);
-    ry = abs(ry);
-
-    const double lambda = (CGFloat) (pow(pxp, 2) / pow(rx, 2) + pow(pyp, 2) / pow(ry, 2));
-
-    if (lambda > 1) {
-        rx *= sqrt(lambda);
-        ry *= sqrt(lambda);
-    }
-
-    const double rxsq =  pow(rx, 2);
-    const double rysq =  pow(ry, 2);
-    const double pxpsq =  pow(pxp, 2);
-    const double pypsq =  pow(pyp, 2);
-
-    double radicant = (rxsq * rysq) - (rxsq * pypsq) - (rysq * pxpsq);
-
-    if (radicant < 0) {
-        radicant = 0;
-    }
-
-    radicant /= (rxsq * pypsq) + (rysq * pxpsq);
-    radicant = sqrt(radicant) * (largeArcFlag == sweepFlag ? -1 : 1);
-
-    const double centerxp = radicant * rx / ry * pyp;
-    const double centeryp = radicant * -ry / rx * pxp;
-
-    const double centerx = cosphi * centerxp - sinphi * centeryp + (px + cx) / 2;
-    const double centery = sinphi * centerxp + cosphi * centeryp + (py + cy) / 2;
-
-    const double vx1 = (pxp - centerxp) / rx;
-    const double vy1 = (pyp - centeryp) / ry;
-    const double vx2 = (-pxp - centerxp) / rx;
-    const double vy2 = (-pyp - centeryp) / ry;
-
-    double ang1 = vectorAngle(1, 0, vx1, vy1);
-    double ang2 = vectorAngle(vx1, vy1, vx2, vy2);
-
-    if (sweepFlag == 0 && ang2 > 0) {
-        ang2 -= TAU;
-    }
-
-    if (sweepFlag == 1 && ang2 < 0) {
-        ang2 += TAU;
-    }
-
-    const int segments = (int) MAX(ceil(abs(ang2) / (TAU / 4.0)), 1.0);
-
-    ang2 /= segments;
-
-    for (int i = 0; i < segments; i++) {
-
-        const double a = 4.0 / 3.0 * tan(ang2 / 4.0);
-
-        const double x1 = cos(ang1);
-        const double y1 = sin(ang1);
-        const double x2 = cos(ang1 + ang2);
-        const double y2 = sin(ang1 + ang2);
-
-        CGPoint p1 = mapToEllipse(x1 - y1 * a, y1 + x1 * a, rx, ry, cosphi, sinphi, centerx, centery);
-        CGPoint p2 = mapToEllipse(x2 + y2 * a, y2 - x2 * a, rx, ry, cosphi, sinphi, centerx, centery);
-        CGPoint p = mapToEllipse(x2, y2, rx, ry, cosphi, sinphi, centerx, centery);
-
-        CGPathAddCurveToPoint(_path, NULL, p1.x, p1.y, p2.x, p2.y, p.x, p.y);
-        _lastControlPoint = p2;
-
-        ang1 += ang2;
+    
+    for(NSUInteger offset = 0; offset < _operands.size(); offset += 7) {
+        CGPoint const currentPoint = CGPathGetCurrentPoint(_path);
+        
+        double const px = currentPoint.x;
+        double const py = currentPoint.y;
+        double rx = _operands[offset];
+        double ry = _operands[offset+1];
+        double const xAxisRotation = _operands[offset+2];
+        double const largeArcFlag = _operands[offset+3];
+        double const sweepFlag = _operands[offset+4];
+        double const cx = _operands[offset+5] + (_cmd == 'a' ? currentPoint.x : 0);
+        double const cy = _operands[offset+6] + (_cmd == 'a' ? currentPoint.y : 0);
+        
+        const double TAU = M_PI * 2.0;
+        
+        const double sinphi = sin(xAxisRotation * TAU / 360);
+        const double cosphi = cos(xAxisRotation * TAU / 360);
+        
+        const double pxp = cosphi * (px - cx) / 2 + sinphi * (py - cy) / 2;
+        const double pyp = -sinphi * (px - cx) / 2 + cosphi * (py - cy) / 2;
+        
+        if (pxp == 0 && pyp == 0) {
+            return;
+        }
+        
+        rx = abs(rx);
+        ry = abs(ry);
+        
+        const double lambda = (CGFloat) (pow(pxp, 2) / pow(rx, 2) + pow(pyp, 2) / pow(ry, 2));
+        
+        if (lambda > 1) {
+            rx *= sqrt(lambda);
+            ry *= sqrt(lambda);
+        }
+        
+        const double rxsq =  pow(rx, 2);
+        const double rysq =  pow(ry, 2);
+        const double pxpsq =  pow(pxp, 2);
+        const double pypsq =  pow(pyp, 2);
+        
+        double radicant = (rxsq * rysq) - (rxsq * pypsq) - (rysq * pxpsq);
+        
+        if (radicant < 0) {
+            radicant = 0;
+        }
+        
+        radicant /= (rxsq * pypsq) + (rysq * pxpsq);
+        radicant = sqrt(radicant) * (largeArcFlag == sweepFlag ? -1 : 1);
+        
+        const double centerxp = radicant * rx / ry * pyp;
+        const double centeryp = radicant * -ry / rx * pxp;
+        
+        const double centerx = cosphi * centerxp - sinphi * centeryp + (px + cx) / 2;
+        const double centery = sinphi * centerxp + cosphi * centeryp + (py + cy) / 2;
+        
+        const double vx1 = (pxp - centerxp) / rx;
+        const double vy1 = (pyp - centeryp) / ry;
+        const double vx2 = (-pxp - centerxp) / rx;
+        const double vy2 = (-pyp - centeryp) / ry;
+        
+        double ang1 = vectorAngle(1, 0, vx1, vy1);
+        double ang2 = vectorAngle(vx1, vy1, vx2, vy2);
+        
+        if (sweepFlag == 0 && ang2 > 0) {
+            ang2 -= TAU;
+        }
+        
+        if (sweepFlag == 1 && ang2 < 0) {
+            ang2 += TAU;
+        }
+        
+        const int segments = (int) MAX(ceil(abs(ang2) / (TAU / 4.0)), 1.0);
+        
+        ang2 /= segments;
+        
+        for (int i = 0; i < segments; i++) {
+            
+            const double a = 4.0 / 3.0 * tan(ang2 / 4.0);
+            
+            const double x1 = cos(ang1);
+            const double y1 = sin(ang1);
+            const double x2 = cos(ang1 + ang2);
+            const double y2 = sin(ang1 + ang2);
+            
+            CGPoint p1 = mapToEllipse(x1 - y1 * a, y1 + x1 * a, rx, ry, cosphi, sinphi, centerx, centery);
+            CGPoint p2 = mapToEllipse(x2 + y2 * a, y2 - x2 * a, rx, ry, cosphi, sinphi, centerx, centery);
+            CGPoint p = mapToEllipse(x2, y2, rx, ry, cosphi, sinphi, centerx, centery);
+            
+            CGPathAddCurveToPoint(_path, NULL, p1.x, p1.y, p2.x, p2.y, p.x, p.y);
+            _lastControlPoint = p2;
+            
+            ang1 += ang2;
+        }
     }
 }
 


### PR DESCRIPTION
**Current behaviour**:
print "*** Error: Invalid number of parameters for A command"
and abort parsing SVG file

for example this svg - 
`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><path d="M32.48,36.73c-2.22,2.64-2,5.9-2.21,9.28-.74-.14-1.33-.19-1.89-.36a17.79,17.79,0,0,1-10-7.67c-5.85-8.91-8.71-18.52-6.31-29.23.07-.3.12-.61.21-.91C13,5.2,13.28,5,16,5s5.6,0,8.4-.14a31.76,31.76,0,0,0,4.84-.64,4.22,4.22,0,0,1,3.57.53c2.49,1.92,4.26,4.37,4.1,7.67A27,27,0,0,0,38.4,23.13c.75,2,.43,2.77-1.5,3.72a13.74,13.74,0,0,1-16.42-3c-3.15-3.54-2.2-11.32,3.19-13A8.15,8.15,0,0,1,31.21,12c2,1.41,1.71,3.57,1.19,5.53s-1.33,4.11-3.88,4.43A3.54,3.54,0,0,1,25,20.61a4.29,4.29,0,0,1-.5-4.22,3.18,3.18,0,0,1,1-1.23c.89-.69,2.33-.67,2.74.06.55,1,0,1.59-.77,2.14a2.67,2.67,0,0,0-.42.52c.3.85.85.87,1.46.51a3,3,0,0,0,1.28-3,2.47,2.47,0,0,0-2-2,4.14,4.14,0,0,0-4.86,3.26q0,.19-.06.39a9.89,9.89,0,0,0,.64,3.64c1.1,2.76,5.41,3.37,7.77,1.2s3.24-7.17,1.72-10a4.26,4.26,0,0,0-1.24-1.35,9,9,0,0,0-14,5.48c-.77,4.39.33,7.69,3.9,10.43A33.59,33.59,0,0,1,29,33.54,21.8,21.8,0,0,0,32.48,36.73Z"/></svg>`

contains `a31.76,31.76,0,0,0,4.84-.64,4.22,4.22,0,0,1,3.57.53c`
"a" command with 14 arguments
this will give error because _operands.size() != 7

**New behaviour**:
After fix this example will correctly finish parsing

This svg is exported from Adobe Illustrator, so it is a common syntax

I've done this loop-arguments fix in the same way as implemented other commands in PocketSVG

