### PR TITLE
Fix line attributes. Closes #158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. Items under
 - Added support for elliptical arc commands sequence of after a single "a". Vladimir Roganov [#143](https://github.com/pocketsvg/PocketSVG/pull/143)
 - Migrate Demo projects to Xcode 10
 - Fix for OS X Crash (https://github.com/pocketsvg/PocketSVG/issues/136) via [Gabor Nemeth](https://github.com/gabor-nemeth)
+- Fix 1pt line scaling. Sebastian Ludwig [#159](https://github.com/pocketsvg/PocketSVG/pull/159)
 
 ### Internal Changes
 

--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -62,9 +62,7 @@
     for(id pathRef in pathRefs) {
         SVGBezierPath * const uiPath = [self bezierPathWithCGPath:(__bridge CGPathRef)pathRef];
         uiPath->_svgAttributes = [cgAttrs attributesForPath:(__bridge CGPathRef)pathRef] ?: @{};
-        if (uiPath->_svgAttributes[@"stroke-width"]) {
-            uiPath.lineWidth = [uiPath->_svgAttributes[@"stroke-width"] doubleValue];
-        }
+        uiPath.lineWidth = uiPath->_svgAttributes[@"stroke-width"] ? [uiPath->_svgAttributes[@"stroke-width"] doubleValue] : 1.0;
         [paths addObject:uiPath];
     }
     return paths;

--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -22,7 +22,7 @@
     _shapeLayers = [NSMutableArray new];
 #if TARGET_OS_IPHONE
     self.shouldRasterize = YES;
-    self.rasterizationScale = [UIScreen mainScreen].scale;
+    self.rasterizationScale = UIScreen.mainScreen.scale;
 #endif
 }
 
@@ -72,7 +72,7 @@
         }        
         CAShapeLayer * const layer = [CAShapeLayer new];
         #if TARGET_OS_IPHONE
-            layer.contentsScale = [UIScreen mainScreen].scale;
+            layer.contentsScale = UIScreen.mainScreen.scale;
         #endif
 
         if(path.svgAttributes[@"transform"]) {

--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -71,6 +71,7 @@
             continue;
         }        
         CAShapeLayer * const layer = [CAShapeLayer new];
+        layer.contentsScale = [UIScreen mainScreen].scale;
 
         if(path.svgAttributes[@"transform"]) {
             SVGBezierPath * const newPath = [path copy];

--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -22,7 +22,7 @@
     _shapeLayers = [NSMutableArray new];
 #if TARGET_OS_IPHONE
     self.shouldRasterize = YES;
-    self.rasterizationScale = [[UIScreen mainScreen] scale];
+    self.rasterizationScale = [UIScreen mainScreen].scale;
 #endif
 }
 
@@ -71,7 +71,9 @@
             continue;
         }        
         CAShapeLayer * const layer = [CAShapeLayer new];
-        layer.contentsScale = [UIScreen mainScreen].scale;
+        #if TARGET_OS_IPHONE
+            layer.contentsScale = [UIScreen mainScreen].scale;
+        #endif
 
         if(path.svgAttributes[@"transform"]) {
             SVGBezierPath * const newPath = [path copy];
@@ -80,7 +82,7 @@
         }
 
         layer.path = path.CGPath;
-        layer.lineWidth = path.svgAttributes[@"stroke-width"] ? [path.svgAttributes[@"stroke-width"] floatValue] : 1.0;
+        layer.lineWidth = path.lineWidth;
         layer.opacity   = path.svgAttributes[@"opacity"] ? [path.svgAttributes[@"opacity"] floatValue] : 1;
         [self insertSublayer:layer atIndex:(unsigned int)[_shapeLayers count]];
         [_shapeLayers addObject:layer];
@@ -144,9 +146,9 @@
                          ?: [[PSVGColor blackColor] CGColor];
         layer.strokeColor = _strokeColor
                          ?: (__bridge CGColorRef)path.svgAttributes[@"stroke"];
-        if (_scaleLineWidth && path.svgAttributes[@"stroke-width"]) {
+        if (_scaleLineWidth) {
             CGFloat lineScale = (frame.size.width/size.width + frame.size.height/size.height) / 2.0;
-            layer.lineWidth = [path.svgAttributes[@"stroke-width"] floatValue] * lineScale;
+            layer.lineWidth = path.lineWidth * lineScale;
         }
         layer.fillRule = [path.svgAttributes[@"fill-rule"] isEqualToString:@"evenodd"] ? kCAFillRuleEvenOdd : kCAFillRuleNonZero;
         NSString *lineCap = path.svgAttributes[@"stroke-linecap"];


### PR DESCRIPTION
Closes #158 by always setting a `SVGBezierPath.lineWidth` and only checking `scaleLineWidth` to determine if lines should be scaled. 

Since the `stroke-width` attribute is optional, it must not be relied upon when checking if a line should be scaled.

The default fallback value of `svgAttributes[@"stroke-width"]` is `1.0` - which is _also_ the default value of [`UIBezierPath.lineWidth`](https://developer.apple.com/documentation/uikit/uibezierpath/1624349-linewidth). So this PR shouldn't change the current behaviour and only fix the mentioned bug.
