### PR TITLE
Fix named SVG Colors plist file loading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. Items under
 - Migrate Demo projects to Xcode 10
 - Fix for OS X Crash (https://github.com/pocketsvg/PocketSVG/issues/136) via [Gabor Nemeth](https://github.com/gabor-nemeth)
 - Fix 1pt line scaling. Sebastian Ludwig [#159](https://github.com/pocketsvg/PocketSVG/pull/159)
+- Fix named SVG Colors. After code refactor made on commit feafc5f SVGColors plist file was renamed but this were not reflected on plist loading code. [Daniel Coello](https://github.com/danicoello)
 
 ### Internal Changes
 

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -870,7 +870,7 @@ hexTriplet::hexTriplet(NSString *str)
     static NSDictionary *colorMap = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSURL *url = [[NSBundle bundleForClass:[SVGAttributeSet class]] URLForResource:@"Colors" withExtension:@"plist"];
+        NSURL *url = [[NSBundle bundleForClass:[SVGAttributeSet class]] URLForResource:@"SVGColors" withExtension:@"plist"];
         colorMap = [NSDictionary dictionaryWithContentsOfURL:url];
     });
     


### PR DESCRIPTION
Reviewing code I saw that file "SVGColors.plist" was not being properly load on code.

This file was renamed from "Colors.plist" to "SVGColor.plist" on commit feafc5f but code used to load this file was not updated. (line 873 of `SVGEngine.mm`.
