### PR TITLE
Treat SVGColors.plist as a resource instead of source code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Items under
 - Fix for OS X Crash (https://github.com/pocketsvg/PocketSVG/issues/136) via [Gabor Nemeth](https://github.com/gabor-nemeth)
 - Fix 1pt line scaling. Sebastian Ludwig [#159](https://github.com/pocketsvg/PocketSVG/pull/159)
 - Fix named SVG Colors. After code refactor made on commit feafc5f SVGColors plist file was renamed but this were not reflected on plist loading code. [Daniel Coello](https://github.com/danicoello)
+- Fixed Xcode 11 build by treating SVGColors.plist as a resource instead of a source file. (https://github.com/pocketsvg/PocketSVG/issues/163). Chris Vasselli [#168] (https://github.com/pocketsvg/PocketSVG/pull/168)
 
 ### Internal Changes
 

--- a/PocketSVG.podspec
+++ b/PocketSVG.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.frameworks  = 'QuartzCore'
   s.library   = 'xml2', 'stdc++'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
-  s.source_files = 'PocketSVG.{h,mm}', 'SVGBezierPath.{h,mm}', 'SVGEngine.{h,mm}', 'SVGImageView.{h,m}', 'SVGLayer.{h,m}', 'SVGPortability.h', 'SVGColors.plist'
+  s.source_files = 'PocketSVG.{h,mm}', 'SVGBezierPath.{h,mm}', 'SVGEngine.{h,mm}', 'SVGImageView.{h,m}', 'SVGLayer.{h,m}', 'SVGPortability.h'
+  s.resources = 'SVGColors.plist'
   s.ios.source_files = 'SVGImageView_iOS.h'
   s.osx.source_files = 'SVGImageView_Mac.h'
 end


### PR DESCRIPTION
This fixes the "Unexpected duplicate tasks" error when building with Xcode 11. (https://github.com/pocketsvg/PocketSVG/issues/163)

The SVGColors.plist file was being included as a source file, rather than a resource. Xcode 11 seems to find this more problematic than previous versions.