### PR TITLE
Single Path String Parsing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. Items under
 
 ## [Unreleased]
 ### New Features
+- Adds new api method for clients to convert single path string into cgpath.
 ### Internal Changes
 
 ## [2.5.0]

--- a/SVGEngine.h
+++ b/SVGEngine.h
@@ -27,6 +27,15 @@ extern "C" {
  */
 NSArray *CGPathsFromSVGString(NSString *svgString, SVGAttributeSet **attributes);
 
+/*!
+ * @brief Returns a single CGPathRef parsed from the contents of a single string formatted like the d attribute inside a path element
+ *
+ * @param svgString The string containing the SVG formatted path, this is just the path string from the d attribute and no xml
+ *
+ * @return A single CGPathRef object
+ *
+ */
+CGPathRef CGPathFromSVGPathString(NSString *svgString);
 
 /*!
  * @brief Returns SVG representing `paths`

--- a/SVGEngine.mm
+++ b/SVGEngine.mm
@@ -441,6 +441,16 @@ NSArray *CGPathsFromSVGString(NSString * const svgString, SVGAttributeSet **outA
     return paths;
 }
 
+/// This parses a single isolated path. creating a cgpath from just a string formated like the d elemen in a path
+CGPathRef CGPathFromSVGPathString(NSString *svgString) {
+    CGPathRef const path = pathDefinitionParser(svgString).parse();
+    if(!path) {
+        NSLog(@"*** Error: Invalid path attribute");
+        return NULL;
+    } else
+        return path;
+}
+
 NSString *SVGStringFromCGPaths(NSArray * const paths, SVGAttributeSet * const attributes)
 {
     CGRect bounds = CGRectZero;


### PR DESCRIPTION
This adds a new parsing end point so clients can request single path objects parsed just from the d attribute of a path.

This is useful to clients that do their own xml parsing (because they need to handle special cases for text and groups) but want to take advantage of this libraries very fast parsing for path strings.

_Thank you for submitting a PR for PocketSVG_ 😀

* If you're fixing an issue, please briefly describe the current behaviour and the new behaviour. If you're addressing an [open issue](https://github.com/pocketsvg/PocketSVG/issues), please link to it.

* If you're introducing a new feature, please briefly describe the new behavior and provide code + sample SVGs for us to see it in action. 

Please also add that as an entry in our [`CHANGELOG.md`](https://github.com/pocketsvg/PocketSVG/blob/master/CHANGELOG.md) file to explain your changes and credit yourself. Add the entry in the appropriate section (New Features / Fixes / Internal Change / Breaking Change) under `Unreleased`. Add links to your GitHub profile and to the related PR and issue after your description. Be part of history.
