### PR TITLE
Remove Xcode 13 SPM related warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
             name: "PocketSVG",
             dependencies: [],
             path: "Sources",
-            exclude: ["Demos", "ci", "derived_data", "PocketSVG.podspec"],
             resources: [
                 .process("Resources"),
             ]
@@ -31,7 +30,6 @@ let package = Package(
             name: "PocketSVGTests",
             dependencies: ["PocketSVG"],
             path: "Tests",
-            exclude: ["Demos", "ci", "derived_data", "PocketSVG.podspec"],
             resources: [
                 .process("Resources")
             ]


### PR DESCRIPTION
**Issue description**:
Xcode 13 displays 4 warnings when PocketSVG is imported using SPM. These warnings are displayed because the Xcode is not able to find "Demos", "ci", "derived_data" and "PocketSVG.podspec". The issue is that these files/folders are mentioned in the exclude field of the package definition but the paths are relative to the path of the target. These files/folders are in the parent of the target source folder, so Xcode doesn't find them.

**Fix applied**:
To fix the problem I have removed the exclude field from the project description since it doesn't prevent Xcode from downloading those files/folders. 
Other could be to add the parent folder, something like:
```swift
    exclude: ["../Demos", "../ci", "../derived_data", "../PocketSVG.podspec"],
```
I haven't tested it. not sure if it will work properly. 

