### PR TITLE
Support for leading zeros shortcut for path's values (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. Items under
 
 ## [Unreleased]
 ### Fixes
-- Support for shortcuts with leading zeros as described in issue (https://github.com/pocketsvg/PocketSVG/issues/204) [Vladimir Roganov](https://github.com/elisar4) [#203](https://github.com/pocketsvg/PocketSVG/pull/203)
+- Support for shortcuts with leading zeros as described in issue (https://github.com/pocketsvg/PocketSVG/issues/204) [Vladimir Roganov](https://github.com/elisar4) [#205](https://github.com/pocketsvg/PocketSVG/pull/205)
 
 ## [2.7.2]
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. Items under **Unreleased** are currently available on **master**'s HEAD, but not yet tagged.
 
 ## [Unreleased]
+### Fixes
+- Support for shortcuts with leading zeros as described in issue (https://github.com/pocketsvg/PocketSVG/issues/204) [Vladimir Roganov](https://github.com/elisar4) [#203](https://github.com/pocketsvg/PocketSVG/pull/203)
 
 ## [2.7.2]
 ### Fixes

--- a/Sources/SVGEngine.mm
+++ b/Sources/SVGEngine.mm
@@ -514,6 +514,15 @@ NSString *SVGStringFromCGPaths(NSArray * const paths, SVGAttributeSet * const at
 pathDefinitionParser::pathDefinitionParser(NSString *aDefinition)
 {
     _definition = [aDefinition stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSRegularExpression * const leadingZerosRegex = [NSRegularExpression regularExpressionWithPattern:@"(?<=[ ,])0\\d"
+                                                                                              options:0
+                                                                                                error:nil];
+    while (NSTextCheckingResult *match = [leadingZerosRegex firstMatchInString:_definition
+                                                                       options:0
+                                                                         range:NSMakeRange(0, _definition.length)]) {
+        _definition = [_definition stringByReplacingCharactersInRange:NSMakeRange(match.range.location, 1)
+                                                           withString:@"0 "];
+    }
 }
 
 CF_RETURNS_RETAINED CGMutablePathRef pathDefinitionParser::parse()

--- a/Tests/PocketSVGTests.swift
+++ b/Tests/PocketSVGTests.swift
@@ -235,12 +235,12 @@ class PocketSVGTests: XCTestCase {
     func testPathValuesWithLeadingZeros() throws {
         let svgString = """
             <svg xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 0 a 2 1 0 0 0 6 0" />
+                <path d="M 0 0.01 a 2 1 0 0 0 6 0 a 0.24 0.52 0 0 0 0 1001" />
             </svg>
             """
         let shortcutSvgString = """
             <svg xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 0 a 2 1 0 006 0" />
+                <path d="M 00.01 a 2 1 0 006 0 a 0.24.52 000 01001" />
             </svg>
             """
         let paths = SVGBezierPath.paths(fromSVGString: svgString)

--- a/Tests/PocketSVGTests.swift
+++ b/Tests/PocketSVGTests.swift
@@ -227,4 +227,28 @@ class PocketSVGTests: XCTestCase {
         let path = paths.first!
         XCTAssertEqual(path.cgPath.boundingBox, CGRect(x: 21, y: 21, width: 470, height: 470))
     }
+
+    /**
+     * Test that leading zeros shortcuts are not ignored and properly parsed
+     * https://github.com/pocketsvg/PocketSVG/issues/204
+     */
+    func testPathValuesWithLeadingZeros() throws {
+        let svgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 0 a 2 1 0 0 0 6 0" />
+            </svg>
+            """
+        let shortcutSvgString = """
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 0 a 2 1 0 006 0" />
+            </svg>
+            """
+        let paths = SVGBezierPath.paths(fromSVGString: svgString)
+        let elementCount = try XCTUnwrap(paths.first?.elementCount)
+        XCTAssertEqual(elementCount, 3, "Elements count in reference path should be equal to 3")
+
+        let shortcutPaths = SVGBezierPath.paths(fromSVGString: shortcutSvgString)
+        let shortcutElementCount = try XCTUnwrap(shortcutPaths.first?.elementCount)
+        XCTAssertEqual(elementCount, shortcutElementCount, "Elements count of shortcut path should be equal to reference path elements count")
+    }
 }

--- a/Tests/PocketSVGTests.swift
+++ b/Tests/PocketSVGTests.swift
@@ -244,11 +244,9 @@ class PocketSVGTests: XCTestCase {
             </svg>
             """
         let paths = SVGBezierPath.paths(fromSVGString: svgString)
-        let elementCount = try XCTUnwrap(paths.first?.elementCount)
-        XCTAssertEqual(elementCount, 3, "Elements count in reference path should be equal to 3")
-
+        let cgPath = try XCTUnwrap(paths.first?.cgPath)
         let shortcutPaths = SVGBezierPath.paths(fromSVGString: shortcutSvgString)
-        let shortcutElementCount = try XCTUnwrap(shortcutPaths.first?.elementCount)
-        XCTAssertEqual(elementCount, shortcutElementCount, "Elements count of shortcut path should be equal to reference path elements count")
+        let shortcutCgPath = try XCTUnwrap(shortcutPaths.first?.cgPath)
+        XCTAssertEqual(cgPath, shortcutCgPath, "Reference and shortcut paths should be equal")
     }
 }


### PR DESCRIPTION
This PR fixes issue https://github.com/pocketsvg/PocketSVG/issues/204 in short: svg's path values can be described using leading zeros shortcuts to eliminate extra spaces (ex. 2 1 0 006 0). Current behaviour is ignoring these shortcuts and won't parse path correctly

Preprocess step for path definition string added to solve this issue. Preprocess replaces all matches of simple regex 
`(?<=[ ,])0\d` with `0 ` on path string. Regex translates as "separator zero + anyDigit". 
<details>
  <summary>Note: this method may affect parsing performance.</summary>
// TODO: add parsing performance tests to keep track with updates :)
</details>
