### PR TITLE
Fix build failure on visionOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file. Items under
 
 ## [Unreleased]
 ### Fixes
-- Support for shortcuts with leading zeros as described in issue (https://github.com/pocketsvg/PocketSVG/issues/204) [Vladimir Roganov](https://github.com/elisar4) [#205](https://github.com/pocketsvg/PocketSVG/pull/205)
+- Support for shortcuts with leading zeros as described in issue (https://github.com/pocketsvg/PocketSVG/issues/212) [Chris Vasselli](https://github.com/chrisvasselli)
+- Fix build on visionOS (https://github.com/pocketsvg/PocketSVG/issues/204) [Vladimir Roganov](https://github.com/elisar4) [#205](https://github.com/pocketsvg/PocketSVG/pull/205)
 
 ## [2.7.2]
 ### Fixes

--- a/Sources/SVGLayer.m
+++ b/Sources/SVGLayer.m
@@ -20,7 +20,7 @@
 - (void)commonInit
 {
     _shapeLayers = [NSMutableArray new];
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_XR
     self.shouldRasterize = YES;
     self.rasterizationScale = UIScreen.mainScreen.scale;
 #endif
@@ -75,7 +75,7 @@
             continue;
         }        
         CAShapeLayer * const layer = [CAShapeLayer new];
-        #if TARGET_OS_IPHONE
+        #if TARGET_OS_IPHONE && !TARGET_OS_XR
             layer.contentsScale = UIScreen.mainScreen.scale;
         #endif
 


### PR DESCRIPTION
Fix for issue https://github.com/pocketsvg/PocketSVG/issues/212

I'm _think_ this is the correct change, but I'm not totally sure, since I'm not totally sure how visionOS handles rendering vector graphics, and I don't see any way to get access to a recommended rasterization scale. But I tried this version (no rasterization), and rasterization with the scale hardcoded to 1x, 2x, and 3x, and you can see the results below. This me getting right up close to the window displaying the "simple - lines" demo. To my eyes, 2x, 3x, and no rasterization all look the same.

Interestingly, I see sharp lines on the no-rastering version while moving in closer to the window, but as soon as I settle it seems to render it at a 2x scale. So I think disabling rasterization may make things look better while a user is moving around?

No rastering
![no-rastering](https://github.com/pocketsvg/PocketSVG/assets/227043/98e340f9-9824-46a7-a16b-008a0189d1c7)

1x scaling
![1x scale](https://github.com/pocketsvg/PocketSVG/assets/227043/ffdd83e1-a570-48ad-b54f-fd059eedb6a4)
2x scaling
![2x scale](https://github.com/pocketsvg/PocketSVG/assets/227043/72fd2fae-46e9-4b9a-a78f-f63842bc44e5)
3x scaling
![3x scale](https://github.com/pocketsvg/PocketSVG/assets/227043/23306103-2cfc-4bb3-9f40-8fc7be3950c3)
