### PR TITLE
Fix typos of the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file. Items under
 
 ## [2.7.1]
 ### Fixes
-- Address Xode 13 related warnings. [Sergio Baró](https://www.github.com/sergiobaro) [#195](https://github.com/pocketsvg/PocketSVG/pull/195)
+- Address Xcode 13 related warnings. [Sergio Baró](https://www.github.com/sergiobaro) [#195](https://github.com/pocketsvg/PocketSVG/pull/195)
 
 ## [2.7.0]
 ### New Features

--- a/Sources/SVGEngine.mm
+++ b/Sources/SVGEngine.mm
@@ -441,7 +441,7 @@ NSArray *CGPathsFromSVGString(NSString * const svgString, SVGAttributeSet **outA
     return paths;
 }
 
-/// This parses a single isolated path. creating a cgpath from just a string formated like the d elemen in a path
+/// This parses a single isolated path. creating a cgpath from just a string formatted like the d element in a path
 CGPathRef CGPathFromSVGPathString(NSString *svgString) {
     CGPathRef const path = pathDefinitionParser(svgString).parse();
     if(!path) {


### PR DESCRIPTION
Fix typos in the comments of the project and the CHANGELOG file. All backwards compatible