### PR TITLE
Add Empty Privacy Manifest

### DIFF
--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+  </dict>
+</plist>


### PR DESCRIPTION
This PR adds an empty Apple Privacy Manifest (PrivacyInfo.xcprivacy) to the project. While the manifest does not contain any specific privacy-related declarations at this stage, its inclusion helps meet Apple’s new privacy requirements and prepares the project for future updates that may involve handling sensitive data.

### Why is this needed?

- Apple’s Privacy Requirements: Starting with Xcode 15 and iOS 17, Apple requires all apps to include a Privacy Manifest to specify how they use sensitive APIs and third-party SDKs.
- Future-Proofing: Even though our app does not require privacy declarations now, adding this placeholder ensures compliance with future changes.
- Avoid App Store Rejection: Having an empty manifest prevents potential warnings or issues when submitting the app to the App Store.

### Changes:

- Added PrivacyInfo.xcprivacy to the project root (inside the Resources folder).
- The file currently has no declared NSPrivacyAccessedAPITypes.

### Testing:

- The app builds and runs successfully without any issues.
- No functional changes introduced.

### References:

- [Apple Developer Documentation: Privacy Manifests](https://developer.apple.com/documentation/bundleresources/privacy_manifest)