### PR TITLE
Fix the issue that zero has been ignored

### DIFF
--- a/Sources/SVGEngine.mm
+++ b/Sources/SVGEngine.mm
@@ -530,7 +530,7 @@ CF_RETURNS_RETAINED CGMutablePathRef pathDefinitionParser::parse()
     dispatch_once(&onceToken, ^{
         commands   = [NSCharacterSet characterSetWithCharactersInString:kValidSVGCommands];
         separators = [NSMutableCharacterSet characterSetWithCharactersInString:@","];
-        [(NSMutableCharacterSet *)separators formUnionWithCharacterSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        [(NSMutableCharacterSet *)separators formUnionWithCharacterSet:NSCharacterSet.newlineCharacterSet];
     });
     scanner.charactersToBeSkipped = separators;
 
@@ -549,7 +549,7 @@ CF_RETURNS_RETAINED CGMutablePathRef pathDefinitionParser::parse()
                     scanner.scanLocation -= 2;
                 }
                 for (NSUInteger i = 0; i < zeros; ++i) { _operands.push_back(0.0); }
-
+                while ([scanner scanCharactersFromSet:[NSCharacterSet whitespaceCharacterSet] intoString:NULL]) { }
                 float operand;
                 if (![scanner scanFloat:&operand]) {
                     break;


### PR DESCRIPTION
# Issue
Any SVG string start with 0, has a whitespace after, and comes with dot, will make the zero being ignored.

For example, if there is a SVG string "0 0 0 .25", it will get "0" "0" "0.25", which we expect "0" "0" "0" "0.25"

# Root cause
In `pathDefinitionParser` we setup the scanner to skip whitespace, which make this string "0 .25" to be recognised as "0.25"

# Fix
- Update skip characters to only newline
- Ignore whitespace in the parser

# Test
## Before

<img width="555" alt="Screenshot 2025-05-15 at 17 57 07" src="https://github.com/user-attachments/assets/a8b7d9ee-37dd-40bc-9f71-59cd977a4f78" />

![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 17 54 58](https://github.com/user-attachments/assets/091e569f-2849-44ba-82b1-86c3877bf3f8)

## After
No error
![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 17 52 49](https://github.com/user-attachments/assets/341dc706-b193-4114-a253-6e05095812e5)