### PR TITLE
Update SVGEngine.mm

### DIFF
--- a/Sources/SVGEngine.mm
+++ b/Sources/SVGEngine.mm
@@ -442,7 +442,7 @@ NSArray *CGPathsFromSVGString(NSString * const svgString, SVGAttributeSet **outA
 }
 
 /// This parses a single isolated path. creating a cgpath from just a string formatted like the d element in a path
-CGPathRef CGPathFromSVGPathString(NSString *svgString) {
+CGPathRef CGPathCreateFromSVGPathString(NSString *svgString) {
     CGPathRef const path = pathDefinitionParser(svgString).parse();
     if(!path) {
         NSLog(@"*** Error: Invalid path attribute");


### PR DESCRIPTION
• pathDefinitionParser(svgString).parse() returns a CGMutablePathRef (which is a Core Foundation object). • The method parse() (see its implementation) creates this object by calling CGPathCreateMutable(), which returns a retained object according to Core Foundation memory management rules.

_Thank you for submitting a PR for PocketSVG_ 😀

* If you're fixing an issue, please briefly describe the current behaviour and the new behaviour. If you're addressing an [open issue](https://github.com/pocketsvg/PocketSVG/issues), please link to it.

* If you're introducing a new feature, please briefly describe the new behavior and provide code + sample SVGs for us to see it in action. 

Please also add that as an entry in our [`CHANGELOG.md`](https://github.com/pocketsvg/PocketSVG/blob/master/CHANGELOG.md) file to explain your changes and credit yourself. Add the entry in the appropriate section (New Features / Fixes / Internal Change / Breaking Change) under `Unreleased`. Add links to your GitHub profile and to the related PR and issue after your description. Be part of history.
